### PR TITLE
Bugs/client module build fail - Remove libs dependencies

### DIFF
--- a/KeywordsApp/ClientApp/package-lock.json
+++ b/KeywordsApp/ClientApp/package-lock.json
@@ -5,12 +5,6 @@
   "packages": {
     "": {
       "name": "clientapp",
-      "dependencies": {
-        "bootstrap": "^4.6.0",
-        "jquery": "^3.6.0",
-        "jquery-validation": "^1.19.3",
-        "jquery-validation-unobtrusive": "^3.2.12"
-      },
       "devDependencies": {
         "cross-env": "^7.0.3",
         "css-loader": "^5.2.0",
@@ -315,19 +309,6 @@
       "dev": true,
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/bootstrap": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.0.tgz",
-      "integrity": "sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/bootstrap"
-      },
-      "peerDependencies": {
-        "jquery": "1.9.1 - 3",
-        "popper.js": "^1.16.1"
       }
     },
     "node_modules/browserslist": {
@@ -837,28 +818,6 @@
         "node": ">= 10.13.0"
       }
     },
-    "node_modules/jquery": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
-    },
-    "node_modules/jquery-validation": {
-      "version": "1.19.3",
-      "resolved": "https://registry.npmjs.org/jquery-validation/-/jquery-validation-1.19.3.tgz",
-      "integrity": "sha512-iXxCS5W7STthSTMFX/NDZfWHBLbJ1behVK3eAgHXAV8/0vRa9M4tiqHvJMr39VGWHMGdlkhrtrkBuaL2UlE8yw==",
-      "peerDependencies": {
-        "jquery": "^1.7 || ^2.0 || ^3.1"
-      }
-    },
-    "node_modules/jquery-validation-unobtrusive": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/jquery-validation-unobtrusive/-/jquery-validation-unobtrusive-3.2.12.tgz",
-      "integrity": "sha512-kPixGhVcuat7vZXngGFfSIksy4VlzZcHyRgnBIZdsfVneCU+D5sITC8T8dD/9c9K/Q+qkMlgp7ufJHz93nKSuQ==",
-      "dependencies": {
-        "jquery": "^3.5.1",
-        "jquery-validation": ">=1.16"
-      }
-    },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -1120,17 +1079,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/postcss": {
@@ -2009,12 +1957,6 @@
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
       "dev": true
     },
-    "bootstrap": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.0.tgz",
-      "integrity": "sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw==",
-      "requires": {}
-    },
     "browserslist": {
       "version": "4.16.6",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
@@ -2378,26 +2320,6 @@
         "supports-color": "^7.0.0"
       }
     },
-    "jquery": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
-    },
-    "jquery-validation": {
-      "version": "1.19.3",
-      "resolved": "https://registry.npmjs.org/jquery-validation/-/jquery-validation-1.19.3.tgz",
-      "integrity": "sha512-iXxCS5W7STthSTMFX/NDZfWHBLbJ1behVK3eAgHXAV8/0vRa9M4tiqHvJMr39VGWHMGdlkhrtrkBuaL2UlE8yw==",
-      "requires": {}
-    },
-    "jquery-validation-unobtrusive": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/jquery-validation-unobtrusive/-/jquery-validation-unobtrusive-3.2.12.tgz",
-      "integrity": "sha512-kPixGhVcuat7vZXngGFfSIksy4VlzZcHyRgnBIZdsfVneCU+D5sITC8T8dD/9c9K/Q+qkMlgp7ufJHz93nKSuQ==",
-      "requires": {
-        "jquery": "^3.5.1",
-        "jquery-validation": ">=1.16"
-      }
-    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -2590,12 +2512,6 @@
       "requires": {
         "find-up": "^4.0.0"
       }
-    },
-    "popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "peer": true
     },
     "postcss": {
       "version": "8.2.13",

--- a/KeywordsApp/ClientApp/package.json
+++ b/KeywordsApp/ClientApp/package.json
@@ -1,12 +1,7 @@
 {
   "name": "clientapp",
   "description": "Build JS and CSS bundles.",
-  "dependencies": {
-    "bootstrap": "^4.6.0",
-    "jquery": "^3.6.0",
-    "jquery-validation": "^1.19.3",
-    "jquery-validation-unobtrusive": "^3.2.12"
-  },
+  "dependencies": {},
   "devDependencies": {
     "cross-env": "^7.0.3",
     "css-loader": "^5.2.0",


### PR DESCRIPTION
Remove bootstraop and Jquery from Webpack project as these are currently managed in a static way.
Solving issue #28 